### PR TITLE
rewrite entrypoint.sh to check if db already initialized

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,16 @@
 #!/bin/sh
-/usr/local/bin/aerich init -t database.config.TORTOISE_ORM
-/usr/local/bin/aerich init-db
-python3 main.py
+FILE=db.*
+DIR=migrations
+
+if [ -n "$FILE" ] && [ -n "$DIR" ]; then
+  echo "Db files with wildcard $FILE and $DIR folder exist."
+  echo "Starting bot"
+  python3 main.py
+else
+  echo "Db files with wildcard $FILE and $DIR folder does not exist."
+  echo "Initializing DB"
+  aerich init -t database.config.TORTOISE_ORM
+  aerich init-db
+  echo "Starting bot"
+  python3 main.py
+fi


### PR DESCRIPTION
Добавлены условия запуска контейнера.
Если файлы базы и папка с миграциями существуют, то считаем, что база инициализрована и просто запускаем бота. В противном случае инициализируем и тоже запускаем

Сделано на случай рестарта контейнера